### PR TITLE
add support of custom project ID for cli

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+BQ_PROJECT=some_project
 BQ_DATASET=some_dataset
 BQ_SCHEMAS_PATH=./schemas
 GOOGLE_APPLICATION_CREDENTIALS=./gcp.credentials.json

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Note that prefix/suffix will be concatenated as is without adding extra separato
 
 Usage example:
 ```sh
-npx nodeart-bq-cli --dataset=my_dataset --schemas-path=./schemas --table-prefix=project1_ --table-suffix=_stage
+npx nodeart-bq-cli --project=my_project --dataset=my_dataset --schemas-path=./schemas --table-prefix=project1_ --table-suffix=_stage
 ```
 
 |                env               |        arg       |  type  | required |            example           |                                               description                                               |
 |:--------------------------------:|:----------------:|:------:|:--------:|:----------------------------:|:-------------------------------------------------------------------------------------------------------:|
+| `BQ_PROJECT`                     | `--project`      | string |    NO    | `my_project`                 | Google Cloud Project ID. If not set, it will be taken from credentials.                                 |
 | `BQ_DATASET`                     | `--dataset`      | string |    YES   | `my_dataset`                 | Dataset ID. Ref: https://cloud.google.com/bigquery/docs/datasets#dataset-naming                         |
 | `BQ_SCHEMAS_PATH`                | `--schemas-path` | string |    YES   | `./path/to/schemas`          | Path to schemas directory                                                                               |
 | `GOOGLE_APPLICATION_CREDENTIALS` |         -        | string |    NO    | `./path/to/credentials.json` | Path to ADC file. Ref: https://cloud.google.com/docs/authentication/application-default-credentials#GAC |

--- a/src/bigQueryService.ts
+++ b/src/bigQueryService.ts
@@ -88,8 +88,8 @@ export class BigQueryService {
   protected readonly projectId;
   protected readonly authService;
 
-  constructor(credentials: ICredentials) {
-    this.projectId = credentials.project_id;
+  constructor(credentials: ICredentials, projectId?: string) {
+    this.projectId = projectId ?? credentials.project_id;
     this.authService = new AuthService(credentials);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { BigQueryNodeService } from './bigQueryNodeService';
 import { cfgString, getDirSchemas, readJsonFile } from './cfgUtils';
 
 const config = {
+  project: cfgString({ envName: 'BQ_PROJECT', argName: 'project' }),
   dataset: cfgString({ envName: 'BQ_DATASET', argName: 'dataset', required: true }),
   schemasPath: cfgString({ envName: 'BQ_SCHEMAS_PATH', argName: 'schemas-path', required: true }),
   tablesPrefix: cfgString({ envName: 'BQ_TABLE_PREFIX', argName: 'table-prefix' }),
@@ -22,7 +23,7 @@ void (async () => {
     throw new Error('Credentials must be specified');
   }
 
-  const bq = await new BigQueryNodeService(credentials);
+  const bq = new BigQueryNodeService(credentials, config.project);
   const schemas = await getDirSchemas(config.schemasPath);
 
   console.log(`Syncing dataset '${config.dataset}'`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Google Cloud Project ID configuration via `--project` CLI argument or `BQ_PROJECT` environment variable, with automatic fallback to the project ID from credentials.

* **Documentation**
  * Updated configuration documentation with new project parameter and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->