### PR TITLE
Feat add view support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changes that have yet to make it into the release version will be listed under `
 
 ## Unreleased
 
+## v1.1.1 - 2026-04-15
+
+### Changed
+
+- Throw error when no schemas are found
+
 ## v1.1.0 - 2026-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes that have yet to make it into the release version will be listed under `
 
 ## Unreleased
 
+### Added
+
+- Support for views
+
 ## v1.1.1 - 2026-04-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Changes that have yet to make it into the release version will be listed under `
 
 ## Unreleased
 
+## v1.2.0 - 2026-04-27
+
 ### Added
 
 - Support for views

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Credentials must be specified either via file path in `GOOGLE_APPLICATION_CREDEN
 
 Schemas to be synced must be located in directory specified in `schemas-path` parameter and named in the following format: `<table name>.schema.json` (e.g. `user.schema.json`). File content must be a valid JSON that satisfies `TableSchema` structure. Ref: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TableSchema.
 
+Schemas to be synced must be located in directory specified in `schemas-path` parameter and named in the following format: `<table name>.view.sql` (e.g. `user.view.sql`). File content must be a valid SQL select statement.
+
 Note that prefix/suffix will be concatenated as is without adding extra separators since BigQuery supports multiple special characters that could be used as separators in tables' names. Ref: https://cloud.google.com/bigquery/docs/tables#table_naming.
 
 Usage example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nodeart/bq-tools",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nodeart/bq-tools",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "jose": "^6.0.11"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nodeart/bq-tools",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nodeart/bq-tools",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "jose": "^6.0.11"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodeart/bq-tools",
-  "version": "1.1,0",
+  "version": "1.1.1",
   "description": "",
   "main": "./build/esm/index.js",
   "types": "./build/esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodeart/bq-tools",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "",
   "main": "./build/esm/index.js",
   "types": "./build/esm/index.d.ts",

--- a/src/bigQueryService.ts
+++ b/src/bigQueryService.ts
@@ -200,6 +200,35 @@ export class BigQueryService {
     }
   }
 
+  public async createOrUpdateViewQuery(datasetId: string, tableId: string, query: string) {
+    let exists = false;
+    try {
+      await this.request(`/datasets/${datasetId}/tables/${tableId}`, 'GET');
+      exists = true;
+    } catch (error) {
+      if (!(error instanceof BigQueryError) || error.code !== 404) {
+        throw error;
+      }
+    }
+
+    const body = {
+      tableReference: {
+        datasetId,
+        projectId: this.projectId,
+        tableId,
+      },
+      view: {
+        query,
+        useLegacySql: false,
+      },
+    };
+    if (exists) {
+      await this.request(`/datasets/${datasetId}/tables/${tableId}`, 'PATCH', body);
+    } else {
+      await this.request(`/datasets/${datasetId}/tables`, 'POST', body);
+    }
+  }
+
   public async insert(
     datasetId: string,
     tableId: string,

--- a/src/cfgUtils.ts
+++ b/src/cfgUtils.ts
@@ -68,3 +68,19 @@ export const getDirSchemas = async (dir: string): Promise<Array<{ name: string; 
     }),
   ).then((arr) => arr.flat());
 };
+
+export const getDirQueries = async (dir: string): Promise<Array<{ name: string; query: string }>> => {
+  const files = await fs.readdir(dir, { withFileTypes: true });
+
+  return Promise.all(
+    files.flatMap(async (f) => {
+      if (f.isFile() && f.name.endsWith('.view.sql')) {
+        const query = await fs.readFile(path.resolve(dir, f.name), { encoding: 'utf-8' });
+
+        return [{ name: path.basename(f.name, '.view.sql'), query }];
+      }
+
+      return [];
+    }),
+  ).then((arr) => arr.flat());
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import { AuthService, ICredentials } from './authService';
 import { BigQueryNodeService } from './bigQueryNodeService';
-import { cfgString, getDirSchemas, readJsonFile } from './cfgUtils';
+import { cfgString, getDirQueries, getDirSchemas, readJsonFile } from './cfgUtils';
 
 const config = {
   project: cfgString({ envName: 'BQ_PROJECT', argName: 'project' }),
@@ -25,10 +25,20 @@ void (async () => {
 
   const bq = new BigQueryNodeService(credentials, config.project);
   const schemas = await getDirSchemas(config.schemasPath);
+  const queries = await getDirQueries(config.schemasPath);
 
-  if (schemas.length === 0) {
-    throw new Error('No Schemas found');
+  if (schemas.length === 0 && queries.length === 0) {
+    throw new Error('No table schemas or view queries found');
   }
+
+  const tableNames = schemas.map((s) => s.name);
+  const viewNames = queries.map((s) => s.name);
+  for (const tableName of tableNames) {
+    if (viewNames.includes(tableName)) {
+      throw new Error('Table and view name collision');
+    }
+  }
+
   console.log(`Syncing dataset '${config.dataset}'`);
   await bq.createDatasetIfNotExists(config.dataset);
 
@@ -37,5 +47,12 @@ void (async () => {
 
     console.log(`Syncing table '${config.dataset}.${tableId}'`);
     await bq.createOrUpdateTableSchema(config.dataset, tableId, schema);
+  }
+
+  for (const { name, query } of queries) {
+    const tableId = `${config.tablesPrefix ?? ''}${name}${config.tablesSuffix ?? ''}`;
+
+    console.log(`Syncing view '${config.dataset}.${tableId}'`);
+    await bq.createOrUpdateViewQuery(config.dataset, tableId, query);
   }
 })();


### PR DESCRIPTION
closes https://github.com/NodeArt/bq-tools/issues/3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync and upsert BigQuery views from .view.sql files in a configurable directory; supports naming prefixes/suffixes and rejects name collisions between tables and views.

* **Bug Fixes**
  * Corrected package version.

* **Documentation**
  * README and changelog updated to document view support and the new release.

* **Behavioral Changes**
  * Now requires at least one table schema or view query; errors if none are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->